### PR TITLE
Pokeball preference in config, Improve frame input accuracy and auto-battle move selection

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -15,6 +15,11 @@ catch:
 - spore
 - perfect_ivs
 battle: []
+pokeball_priority:
+- premier_ball
+- ultra_ball
+- great_ball
+- poke_ball
 starter_pokemon: Mudkip
 eco_mode: true
 game_save:
@@ -40,31 +45,70 @@ control_map:
   - r
 banned_moves:
 - None
+  # 2-turn
+- Bounce
+- Dig
+- Dive
+- Fly
+- Sky Attack
+- Razor Wind
+- Doom Desire
+- Solar Beam
+  # Inconsistent
+- Fake Out
+- False Swipe
+- Nature Power
+- Present
+- Destiny Bond
+- Wrap
+- Snore
+- Spit Up
 - Bide
 - Bind
 - Counter
-- Destiny Bond
-- Dig
-- Dive
-- Doom Desire
-- Explosion
-- Fake Out
-- False Swipe
-- Fly
 - Future Sight
 - Mirror Coat
-- Nature Power
-- Perish Song
-- Present
-- Razor Wind
+- Grudge
+- Snatch
+- Spite
+- Curse
+- Endeavor
 - Revenge
-- Selfdestruct
-- Sky Attack
-- Snore
-- Spit Up
+- Assist
+- Focus Punch
+- Eruption
+- Flail
+  # Ends battle
+- Roar
 - Whirlwind
-- Wrap
+- Selfdestruct
+- Perish Song
+- Explosion
+- Memento
 no_sleep_pokemon:
+  # Shed Skin
+- Metapod
+- Kakuna
+- Ekans
+- Arbok
+- Dratini
+- Dragonair
+- Pupitar
+- Silcoon
+- Cascoon
+- Seviper
+  # Vital Spirit
+- Mankey
+- Primeape
+- Electabuzz
+- Magmar
+- Tyrogue
+- Elekid
+- Magby
+- Vigoroth
+  # Insomnia
+- Drowzee
+- Hypno
 - Hoothoot
 - Noctowl
 - Spinarak
@@ -73,6 +117,3 @@ no_sleep_pokemon:
 - Delibird
 - Shuppet
 - Banette
-- Honchkrow
-- Pumpkaboo
-- Ghourgeist

--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -528,7 +528,7 @@
         "name": "Clefairy",
         "number": 35,
         "type": [
-            "Fairy"
+            "Normal"
         ],
         "base": {
             "HP": 70,
@@ -543,7 +543,7 @@
         "name": "Clefable",
         "number": 36,
         "type": [
-            "Fairy"
+            "Normal"
         ],
         "base": {
             "HP": 95,
@@ -588,8 +588,7 @@
         "name": "Jigglypuff",
         "number": 39,
         "type": [
-            "Normal",
-            "Fairy"
+            "Normal"
         ],
         "base": {
             "HP": 115,
@@ -604,8 +603,7 @@
         "name": "Wigglytuff",
         "number": 40,
         "type": [
-            "Normal",
-            "Fairy"
+            "Normal"
         ],
         "base": {
             "HP": 140,
@@ -1871,8 +1869,7 @@
         "name": "Mr. Mime",
         "number": 122,
         "type": [
-            "Psychic",
-            "Fairy"
+            "Psychic"
         ],
         "base": {
             "HP": 40,
@@ -2659,7 +2656,7 @@
         "name": "Cleffa",
         "number": 173,
         "type": [
-            "Fairy"
+            "Normal"
         ],
         "base": {
             "HP": 50,
@@ -2674,8 +2671,7 @@
         "name": "Igglybuff",
         "number": 174,
         "type": [
-            "Normal",
-            "Fairy"
+            "Normal"
         ],
         "base": {
             "HP": 90,
@@ -2690,7 +2686,7 @@
         "name": "Togepi",
         "number": 175,
         "type": [
-            "Fairy"
+            "Normal"
         ],
         "base": {
             "HP": 35,
@@ -2705,7 +2701,7 @@
         "name": "Togetic",
         "number": 176,
         "type": [
-            "Fairy",
+            "Normal",
             "Flying"
         ],
         "base": {
@@ -2813,8 +2809,7 @@
         "name": "Marill",
         "number": 183,
         "type": [
-            "Water",
-            "Fairy"
+            "Water"
         ],
         "base": {
             "HP": 70,
@@ -2829,8 +2824,7 @@
         "name": "Azumarill",
         "number": 184,
         "type": [
-            "Water",
-            "Fairy"
+            "Water"
         ],
         "base": {
             "HP": 100,
@@ -3217,7 +3211,7 @@
         "name": "Snubbull",
         "number": 209,
         "type": [
-            "Fairy"
+            "Normal"
         ],
         "base": {
             "HP": 60,
@@ -3232,7 +3226,7 @@
         "name": "Granbull",
         "number": 210,
         "type": [
-            "Fairy"
+            "Normal"
         ],
         "base": {
             "HP": 90,
@@ -4319,8 +4313,7 @@
         "name": "Ralts",
         "number": 280,
         "type": [
-            "Psychic",
-            "Fairy"
+            "Psychic"
         ],
         "base": {
             "HP": 28,
@@ -4335,8 +4328,7 @@
         "name": "Kirlia",
         "number": 281,
         "type": [
-            "Psychic",
-            "Fairy"
+            "Psychic"
         ],
         "base": {
             "HP": 38,
@@ -4351,8 +4343,7 @@
         "name": "Gardevoir",
         "number": 282,
         "type": [
-            "Psychic",
-            "Fairy"
+            "Psychic"
         ],
         "base": {
             "HP": 68,
@@ -4598,8 +4589,7 @@
         "name": "Azurill",
         "number": 298,
         "type": [
-            "Normal",
-            "Fairy"
+            "Normal"
         ],
         "base": {
             "HP": 50,
@@ -4675,8 +4665,7 @@
         "name": "Mawile",
         "number": 303,
         "type": [
-            "Steel",
-            "Fairy"
+            "Steel"
         ],
         "base": {
             "HP": 50,


### PR DESCRIPTION
### Bot
- Created enums for GameState, MapBank and MapID to ease code readability (Map enums include all static encounter locations except sudowoodo)
- Added 'player_on_map()' to identify the current map in a cleaner manner
- Replaced instances of blank debug output with Exceptions to aid troubleshooting
- Added 'frames_to_ms()' to provide more accurate input timings; reduces the number of dropped inputs
- Further simplified the Premier Ball buying method
- Reworked the auto-battle move selection to account for type effectiveness and STAB in a new method 'find_effective_move'

### Config
- Added an option to specify Pokeball types in order of preference to catch wild Pokemon with
- Added some species with Vital Spirit and Shed Skin to no_sleep_pokemon
- Added more inconsistent & battle-ruining moves to banned_moves, including Bounce, Assist, Focus Punch, Memento etc...

### Data
- Removed every instance of Fairy type in pokemon.json as it doesn't exist yet & made type matchups inaccurate
