### PR TITLE
Basic Discord Webhook logging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -34,6 +34,8 @@ from data.GameState import GameState
 from data.MapData import mapRSE #mapFRLG
 # Data processing
 import pandas as pd
+# Webhook stuffs
+from discord_webhook import DiscordWebhook, DiscordEmbed
 
 no_sleep_abilities = ["Shed Skin", "Insomnia", "Vital Spirit"]
 pickup_pokemon = ["Meowth", "Aipom", "Phanpy", "Teddiursa", "Zigzagoon", "Linoone"]
@@ -831,6 +833,30 @@ def log_encounter(pokemon: dict):
         shortest_phase = stats["totals"]["shortest_phase_encounters"]
         encounters = stats["totals"]["phase_encounters"]
 
+        # Send webhook message, if enabled.
+        if config["discord_webhook_url"]:
+            debug_log.info("Sending Discord ping...")
+            if config["discord_shiny_ping"] and config["discord_ping_mode"] == "role": # Thanks Discord for making role and user IDs use the same format, but have different syntaxes for pinging them by ID, really cool.
+                content=f"<@&{config['discord_shiny_ping']}>"
+            elif config["discord_ping_mode"] == "user":
+                content=f"<@{config['discord_shiny_ping']}>"
+            else:
+                content="" # It breaks if I don't do this, sorry.
+            webhook = DiscordWebhook(url=config["discord_webhook_url"], content=content)
+            embed = DiscordEmbed(title='Shiny encountered!', description=f"{pokemon['name']} at {pokemon['metLocationName']}", color='ffd242')
+            embed.set_footer(text='PokeBot')
+            embed.set_timestamp()
+            embed.add_embed_field(name='Shiny Value', value=f"{pokemon['shinyValue']:,}")
+            embed.add_embed_field(name='Nature', value=f"{pokemon['nature']}")
+            embed.add_embed_field(name='IVs', value=f"HP: {pokemon['hpIV']} | ATK: {pokemon['attackIV']} | DEF: {pokemon['defenseIV']} | SPATK: {pokemon['spAttackIV']} | SPDEF: {pokemon['spDefenseIV']} | SPE: {pokemon['speedIV']}", inline=False)
+            embed.add_embed_field(name='Species Phase Encounters', value=f"{stats['pokemon'][mon_name]['phase_encounters']}")
+            embed.add_embed_field(name='All Phase Encounters', value=f"{stats['totals']['phase_encounters']}")
+            with open(f"interface/sprites/pokemon/shiny/{pokemon['name']}.png", "rb") as shiny:
+                webhook.add_file(file=shiny.read(), filename='shiny.png')
+            embed.set_thumbnail(url='attachment://shiny.png')
+            webhook.add_embed(embed)
+            response = webhook.execute()
+        
         if shortest_phase == "-": 
             shortest_phase = encounters
         else:

--- a/config.yml
+++ b/config.yml
@@ -40,6 +40,14 @@ johto_starter: Cyndaquil
 fossil: Anorith
 deoxys_puzzle_solved: false
 
+# Discord Webhook settings (optional)
+discord_webhook_url:
+# Your raw webhook URL here, if unspecified, the function's disabled.
+discord_ping_mode: role
+# "user" or "role", if left empty/invalid: pings are disabled.
+discord_shiny_ping: 
+# Discord User/Role ID to ping. Does nothing if "discord_ping_mode" isn't set. Currently supports only one at a time.
+
 # Wild Battles
 manual_catch: false
 use_spore: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ ruamel.yaml==0.17.21
 pywebview==4.0.2
 fastjsonschema==2.16.3
 pandas==2.0.2
+discord-webhook==1.1.0


### PR DESCRIPTION
Adds (completely optional) integration with a Discord webhook to send notifications of any shinies encountered and optionally: ping a role/user (although right now it's only one, and it's a tad jank due to Discord's handling of IDs and pinging by ID).
I've confirmed it works just fine, although a little more testing from others would be appreciated.
To set up a webhook, set up a test Discord server, refer to the "Making a Webhook" section of [This Discord Support article](https://support.discord.com/hc/en-us/articles/228383668), then just paste your webhook link into the appropriate config value.
For the user/role IDs:
1. Go to your User Settings (cog next to your name/pfp/voice chat controls)
2. Navigate to "Advanced"
3. Turn on "Developer Mode"
4. Right click on a user/role and select "Copy user ID"/"Copy role ID"
5. Paste it into the "discord_shiny_ping" config option
6. Make sure "discord_ping_mode" is set correctly, I blame Discord for that one.

I'll set up a proper wiki section (with screenshots!) once this gets merged.

Please let me know of any issues anyone encounters.