### PR TITLE
Added margin to sprite classes

### DIFF
--- a/interface/css/pokebot.css
+++ b/interface/css/pokebot.css
@@ -2,6 +2,7 @@ img.sprite64 {
     transform: scale(1.3);
     height: 64px;
     width: 64px;
+    margin-top: 10px; /* Added top margin of 10px */
 }
 
 img.sprite32 {
@@ -14,10 +15,12 @@ img.sprite16 {
     transform: scale(1.5);
     height: 16px;
     width: 16px;
+    margin-left: 5px; /* Added left margin of 5px */
 }
 
 img.icon {
     transform: scale(1.5);
+    margin-left: 5px; /* Added left margin of 5px */
 }
 
 .health-bar {


### PR DESCRIPTION
Added margin properties to the CSS classes 'sprite64', 'sprite16', and 'icon'. These margin adjustments are intended to enhance the spacing and alignment of the corresponding elements within the dashboard layout.

Details:
- The 'sprite64' class now includes a top margin of 10px to introduce vertical spacing. This change will be beneficial for the eventual addition of a "Party" section to the bot.
- Both the 'sprite16' and 'icon' classes have been given a left margin of 5px to create horizontal spacing.

The margin additions have been done for an improved visual presentation and a better positioning of the sprites and icons in the overall design. Your feedback on these changes is welcome.