### PR TITLE
Treeko --> Treecko in comment

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -32,7 +32,7 @@ direction: Horizontal
 starter: Mudkip
 # Torchic
 # Mudkip
-# Treeko
+# Treecko
 johto_starter: Cyndaquil
 # Cyndaquil
 # Chikorita


### PR DESCRIPTION
Fixed comment typo of Treecko being written as "Treeko"