### PR TITLE
Add option to format IV list on discord ping for easier readability

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -844,7 +844,12 @@ def log_encounter(pokemon: dict):
             embed.set_timestamp()
             embed.add_embed_field(name='Shiny Value', value=f"{pokemon['shinyValue']:,}")
             embed.add_embed_field(name='Nature', value=f"{pokemon['nature']}")
-            embed.add_embed_field(name='IVs', value=f"HP: {pokemon['hpIV']} | ATK: {pokemon['attackIV']} | DEF: {pokemon['defenseIV']} | SPATK: {pokemon['spAttackIV']} | SPDEF: {pokemon['spDefenseIV']} | SPE: {pokemon['speedIV']}", inline=False)
+            # Basic IV list
+            if config["discord_webhook_ivs"] == "basic" or config["discord_webhook_ivs"] == "":
+                embed.add_embed_field(name='IVs', value=f"HP: {pokemon['hpIV']} | ATK: {pokemon['attackIV']} | DEF: {pokemon['defenseIV']} | SPATK: {pokemon['spAttackIV']} | SPDEF: {pokemon['spDefenseIV']} | SPE: {pokemon['speedIV']}", inline=False)
+            # Formatted IV list
+            if config["discord_webhook_ivs"] == "formatted":
+                embed.add_embed_field(name='IVs', value=f"`╔═══╤═══╤═══╤═══╤═══╤═══╗`\n`║HP │ATK│DEF│SPA│SPD│SPE║`\n`╠═══╪═══╪═══╪═══╪═══╪═══╣`\n`║{pokemon['hpIV']:^3}│{pokemon['attackIV']:^3}│{pokemon['defenseIV']:^3}│{pokemon['spAttackIV']:^3}│{pokemon['spDefenseIV']:^3}│{pokemon['speedIV']:^3}║`\n`╚═══╧═══╧═══╧═══╧═══╧═══╝`", inline=False)
             embed.add_embed_field(name='Species Phase Encounters', value=f"{stats['pokemon'][mon_name]['phase_encounters']}")
             embed.add_embed_field(name='All Phase Encounters', value=f"{stats['totals']['phase_encounters']}")
             with open(f"interface/sprites/pokemon/shiny/{pokemon['name']}.png", "rb") as shiny:

--- a/config.yml
+++ b/config.yml
@@ -48,6 +48,8 @@ save_every_x_encounters: 1000
 # Discord Webhook settings (optional)
 discord_webhook_url:
 # Your raw webhook URL here, if unspecified, the function's disabled.
+discord_webhook_ivs: formatted 
+# Choose how the IVs will display, either basic layout on one line or formatted for readability
 discord_ping_mode: role
 # "user" or "role", if left empty/invalid: pings are disabled.
 discord_shiny_ping: 


### PR DESCRIPTION
Small change that adds one config (basic/formatted IV list) that greatly increases readability of the discord webhook IV list when a shiny is found
![image](https://github.com/40Cakes/pokebot-bizhawk/assets/22874875/54abdf0d-ceb0-4c8a-87eb-0ef28cd4c330)

Used {string:^3} to ensure that correct spacing was added for the IV list for small numbers. 
Up to maintainers if they want config.yml to default to basic or formatted :)