### PR TITLE
Empty Encounter Log Check

### DIFF
--- a/modules/FlaskServer.py
+++ b/modules/FlaskServer.py
@@ -52,22 +52,22 @@ def httpServer():  # Run Flask server to make bot data available via HTTP GET
 
         @server.route("/encounter", methods=["GET"])
         def Encounter():
-            encounter = GetEncounterLog()["encounter_log"].pop()["pokemon_obj"]
-            if encounter:
-                stats = GetStats()
-                response = json.loads("{}")
-                if stats:
-                    try:
-                        encounter["stats"] = stats["pokemon"][encounter["name"]]
+            if len(GetEncounterLog()["encounter_log"]) > 0:
+                encounter = GetEncounterLog()["encounter_log"].pop()["pokemon_obj"]
+                if encounter:
+                    stats = GetStats()
+                    response = json.loads("{}")
+                    if stats:
+                        try:
+                            encounter["stats"] = stats["pokemon"][encounter["name"]]
+                            response = jsonify(encounter)
+                            return response
+                        except:
+                            abort(503)
+                    else:
                         response = jsonify(encounter)
-                        return response
-                    except:
-                        abort(503)
-                else:
-                    response = jsonify(encounter)
-                return response
-            else:
-                abort(503)
+                    return response
+            abort(503)
 
         @server.route("/emu", methods=["GET"])
         def Emu():

--- a/modules/FlaskServer.py
+++ b/modules/FlaskServer.py
@@ -53,21 +53,16 @@ def httpServer():  # Run Flask server to make bot data available via HTTP GET
         @server.route("/encounter", methods=["GET"])
         def Encounter():
             encounter_logs = GetEncounterLog()["encounter_log"]
-            if len(encounter_logs) > 0:
+            if len(encounter_logs) > 0 and encounter_logs[-1]["pokemon_obj"]:
                 encounter = encounter_logs.pop()["pokemon_obj"]
-                if encounter:
-                    stats = GetStats()
-                    response = json.loads("{}")
-                    if stats:
-                        try:
-                            encounter["stats"] = stats["pokemon"][encounter["name"]]
-                            response = jsonify(encounter)
-                            return response
-                        except:
-                            abort(503)
-                    else:
-                        response = jsonify(encounter)
-                    return response
+                stats = GetStats()
+                if stats:
+                    try:
+                        encounter["stats"] = stats["pokemon"][encounter["name"]]
+                        return jsonify(encounter)
+                    except:
+                        abort(503)
+                return jsonify(encounter)
             abort(503)
 
         @server.route("/emu", methods=["GET"])

--- a/modules/FlaskServer.py
+++ b/modules/FlaskServer.py
@@ -52,8 +52,9 @@ def httpServer():  # Run Flask server to make bot data available via HTTP GET
 
         @server.route("/encounter", methods=["GET"])
         def Encounter():
-            if len(GetEncounterLog()["encounter_log"]) > 0:
-                encounter = GetEncounterLog()["encounter_log"].pop()["pokemon_obj"]
+            encounter_logs = GetEncounterLog()["encounter_log"]
+            if len(encounter_logs) > 0:
+                encounter = encounter_logs.pop()["pokemon_obj"]
                 if encounter:
                     stats = GetStats()
                     response = json.loads("{}")


### PR DESCRIPTION
One user reported this error on a fresh, first time run of the bot:
```
File "C:\...\pokebot-bizhawk\modules\FlaskServer.py", line 55, in Encounter
    encounter = GetEncounterLog()["encounter_log"].pop()["pokemon_obj"]
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IndexError: pop from empty list
```

This appears to be due to the encounter log not having any entries. This resolves that by having a check for the number of logs before attempting to pop it from the dictionary