### PR TITLE
Add Petalburg City battle/heal loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ reports/
 roms/
 .venv
 .idea
+.vs
 bot.spec

--- a/bot.py
+++ b/bot.py
@@ -8,7 +8,7 @@ from modules.Config import GetConfig
 from modules.Inputs import ReleaseAllInputs, PressButton, WaitFrames
 from modules.Stats import EncounterPokemon, OpponentChanged
 from modules.gen3.General import ModeBonk, ModeBunnyHop, ModeFishing, ModeCoords, ModeSpin, ModeSweetScent, \
-    ModePremierBalls
+    ModePremierBalls, ModePetalburgLoop
 from modules.gen3.GiftPokemon import ModeCastform, ModeBeldum, ModeFossil, ModeJohtoStarters
 from modules.gen3.Legendaries import ModeGroudon, ModeKyogre, ModeRayquaza, ModeMew, ModeRegis, ModeSouthernIsland, \
     ModeDeoxysPuzzle, ModeDeoxysResets, ModeHoOh, ModeLugia
@@ -39,6 +39,8 @@ def MainLoop():
                         EncounterPokemon()
                     case "spin":
                         ModeSpin()
+                    case "petalburg loop":
+                        ModePetalburgLoop()
                     case "sweet scent":
                         ModeSweetScent()
                     case "bunny hop":

--- a/config.yml
+++ b/config.yml
@@ -1,7 +1,7 @@
 # Bot config
 
 # Bot mode
-# spin, sweet scent, bunny hop, coords, bonk, fishing, starters, lugia, ho-oh
+# spin, sweet scent, bunny hop, coords, bonk, fishing, starters, lugia, ho-oh, petalburg loop
 # rayquaza, groudon, kyogre, southern island, mew, regis, deoxys runaways
 # deoxys reset, fossil, castform, beldum, johto starters, buy premier balls
 bot_mode: spin

--- a/modules/Stats.py
+++ b/modules/Stats.py
@@ -113,6 +113,11 @@ def OpponentChanged():
         # Fixes a bug where the bot checks the opponent for up to 20 seconds if it was last closed in a battle
         if GetTrainer()["state"] == GameState.OVERWORLD:
             return False
+        
+        #recheck again after 5 frames to avoid infinite loop in GetOpponent
+        WaitFrames(5)
+        if GetTrainer()["state"] == GameState.OVERWORLD:
+            return False
 
         opponent = GetOpponent()
         if opponent:


### PR DESCRIPTION
Intended for use with the Battle config option enabled, primarily to automate Pickup farming.

Based on the following logic/assumptions:
- We are somewhere on the vertical line between Nurse Joy and the entrance to the Pokemon Center in Petalburg City, or the horizontal line between that entrance and the grass to its right (not including the last grass tile)
- By looking at just out X coordinate, we can find out either where we are on the horizontal line, or that we are on the vertical line
- If we have below half HP or not enough PP on acceptable moves in order to battle: 
  - Navigate to the vertical line
  - Once on the vertical line walk up towards Nurse Joy and spam A to get her to heal us
- If we have enough HP and PP:
  - Navigate to the horizontal line (spamming B to get out of any Nurse Joy dialogue)
  - Once on the horizontal line, navigate to the first grass tile
  - Once on the grass tile, try to encounter a pokemon by turning in place
    - We flip between left and right instead of spinning due to the risk of walking off the horizontal line


If there's any questions, feel free to ask here or @ me on the discord server