### PR TITLE
Fix shuppet pokedex ID

### DIFF
--- a/modules/data/routes-emerald.json
+++ b/modules/data/routes-emerald.json
@@ -3127,7 +3127,7 @@
         "encounter_type": "grass"
       },
       {
-        "pokedex_id": 0,
+        "pokedex_id": 353,
         "name": "Shuppet",
         "levels": "27-29",
         "rate": "60%",


### PR DESCRIPTION
Forgot to fix the pokedex ID for shuppet on Mt Pyre Exterior